### PR TITLE
fix: implement bug fix not processing last change ( #12 )

### DIFF
--- a/components/Resume/index.tsx
+++ b/components/Resume/index.tsx
@@ -24,22 +24,30 @@ export const Resume = () => {
   const document = (
     <ResumePDF resume={resume} settings={settings} isPDF={true} suppressErrorMessages={false} />
   );
-  
-  // Key baseada nos dados principais para forçar remontagem do ResumeControlBar
+
+  // Key baseada em todos os dados que afetam o PDF para forçar remontagem do ResumeControlBar
   // quando os dados mudarem, garantindo que usePDF gere o PDF atualizado
-  // Usando uma hash simples dos dados principais
+  // Usando JSON.stringify para capturar todas as mudanças nos objetos
   const controlBarKey = useMemo(() => {
-    const profileHash = `${resume.profile.name}-${resume.profile.email}-${resume.profile.phone}`;
-    const experiencesHash = resume.workExperiences
-      .map((exp) => `${exp.company}-${exp.jobTitle}`)
-      .join("|");
-    const educationsHash = resume.educations
-      .map((edu) => `${edu.school}-${edu.degree}`)
-      .join("|");
-    const projectsHash = resume.projects.map((proj) => proj.project).join("|");
-    const skillsHash = resume.skills.descriptions.join("|");
-    return `${profileHash}-${experiencesHash}-${educationsHash}-${projectsHash}-${skillsHash}-${settings.documentSize}`;
-  }, [resume, settings.documentSize]);
+    const resumeData = {
+      profile: resume.profile,
+      workExperiences: resume.workExperiences,
+      educations: resume.educations,
+      projects: resume.projects,
+      skills: resume.skills,
+      custom: resume.custom,
+    };
+    const settingsData = {
+      themeColor: settings.themeColor,
+      fontFamily: settings.fontFamily,
+      fontSize: settings.fontSize,
+      documentSize: settings.documentSize,
+      formToHeading: settings.formToHeading,
+      formsOrder: settings.formsOrder,
+      showBulletPoints: settings.showBulletPoints,
+    };
+    return JSON.stringify({ resumeData, settingsData });
+  }, [resume, settings]);
 
   useRegisterReactPDFFont();
   useRegisterReactPDFHyphenationCallback(settings.fontFamily);


### PR DESCRIPTION
## Descrição

Foi identificado e corrigido um bug crítico onde alterações em textos das seções (descrições, resumos) e configurações de fonte (família, tamanho, cor) não eram refletidas no arquivo PDF baixado. O PDF mantinha versões anteriores do conteúdo.

## Problema identificado

- O `controlBarKey` usado para forçar a remontagem do componente `ResumeControlBar` (responsável pela geração do PDF) estava incompleto
- A chave só incluía dados parciais do currículo e configurações limitadas, não capturando mudanças em:
  - Descrições completas das experiências profissionais
  - Resumos e textos do perfil
  - Configurações de fonte (família, tamanho, cor do tema)
  - Dados completos de projetos e educação

## Solução implementada

- Atualização do `controlBarKey` para incluir **todos** os dados do currículo e configurações que afetam o PDF
- Uso de `JSON.stringify()` para garantir que qualquer mudança nos objetos seja detectada
- Agora qualquer alteração em texto ou configurações força uma nova geração do PDF
